### PR TITLE
fix for istio 1.1

### DIFF
--- a/trafficshifting/istio/service-mt-retry.yaml
+++ b/trafficshifting/istio/service-mt-retry.yaml
@@ -13,3 +13,4 @@ spec:
     retries:
       attempts: 3
       perTryTimeout: 100ms
+      retryOn: 5xx


### PR DESCRIPTION
Starting with Istio 1.1 you have to specify which conditions to retry on.
Istio 1.1: https://preliminary.istio.io/docs/reference/config/istio.networking.v1alpha3/#HTTPRetry
Envoy: https://www.envoyproxy.io/docs/envoy/latest/configuration/http_filters/router_filter#x-envoy-retry-on